### PR TITLE
Added option to ignore safety checks

### DIFF
--- a/aag/weather.py
+++ b/aag/weather.py
@@ -772,12 +772,18 @@ class AAGCloudSensor(object):
 
         saftey_params = {'cloud': cloud[1], 'wind': wind[1], 'gust': gust[1], 'rain': rain[1]}
 
-        if ignore:
-            for weather_to_ignore in ignore:
-                if weather_to_ignore in saftey_params:
-                    del saftey_params[weather_to_ignore]
-        else:
-            safe = all(saftey_params.values())
+        from panoptes.utils.utils import listify  # at top of file
+        
+        if ignore is not None:
+            for weather_to_ignore in listify(ignore):
+                ignored_value = safety_params.pop(weather_to_ignore)
+
+                # Warn if ignoring an unsafe value.
+                if ignored_value is False:
+                    logger.warning(f'Ignored unsafe value: {weather_to_ignore}={ignored_value}')
+                
+        # Do final safety check.
+        safe = all(safety_params.values())
 
         logger.debug(f'Weather Safe: {safe}')
 

--- a/aag/weather.py
+++ b/aag/weather.py
@@ -748,7 +748,7 @@ class AAGCloudSensor(object):
 
                 self.set_pwm(new_pwm)
 
-    def make_safety_decision(self, current_values, ignore=False):
+    def make_safety_decision(self, current_values, ignore=None):
         """
         Method makes decision whether conditions are safe or unsafe.
 

--- a/aag/weather.py
+++ b/aag/weather.py
@@ -608,7 +608,10 @@ class AAGCloudSensor(object):
             data['wind_speed_KPH'] = self.wind_speed.value
 
         # Make Safety Decision
-        self.safe_dict = self.make_safety_decision(data)
+        if self.config.get('ignore') is not None:
+            self.safe_dict = self.make_safety_decision(data, self.config.get('ignore'))
+        else:
+            self.safe_dict = self.make_safety_decision(data)
 
         data['safe'] = self.safe_dict['Safe']
         data['sky_condition'] = self.safe_dict['Sky']

--- a/aag/weather.py
+++ b/aag/weather.py
@@ -608,8 +608,8 @@ class AAGCloudSensor(object):
             data['wind_speed_KPH'] = self.wind_speed.value
 
         # Make Safety Decision
-        if self.config.get('ignore') is not None:
-            self.safe_dict = self.make_safety_decision(data, self.config.get('ignore'))
+        if self.config.get('ignore_unsafe') is not None:
+            self.safe_dict = self.make_safety_decision(data, self.config.get('ignore_unsafe'))
         else:
             self.safe_dict = self.make_safety_decision(data)
 

--- a/aag/weather.py
+++ b/aag/weather.py
@@ -772,11 +772,12 @@ class AAGCloudSensor(object):
 
         saftey_params = {'cloud': cloud[1], 'wind': wind[1], 'gust': gust[1], 'rain': rain[1]}
 
-        for weather_to_ignore in ignore:
-            if weather_to_ignore in saftey_params:
-                del saftey_params[weather_to_ignore]
-
-        safe = all(saftey_params.values())
+        if ignore:
+            for weather_to_ignore in ignore:
+                if weather_to_ignore in saftey_params:
+                    del saftey_params[weather_to_ignore]
+        else:
+            safe = all(saftey_params.values())
 
         logger.debug(f'Weather Safe: {safe}')
 

--- a/aag/weather.py
+++ b/aag/weather.py
@@ -7,7 +7,7 @@ import numpy as np
 import astropy.units as u
 from loguru import logger
 from panoptes.utils.rs232 import SerialData
-
+from panoptes.utils.utils import listify
 from .PID import PID
 
 
@@ -772,8 +772,6 @@ class AAGCloudSensor(object):
 
         saftey_params = {'cloud': cloud[1], 'wind': wind[1], 'gust': gust[1], 'rain': rain[1]}
 
-        from panoptes.utils.utils import listify  # at top of file
-        
         if ignore is not None:
             for weather_to_ignore in listify(ignore):
                 ignored_value = safety_params.pop(weather_to_ignore)
@@ -781,7 +779,7 @@ class AAGCloudSensor(object):
                 # Warn if ignoring an unsafe value.
                 if ignored_value is False:
                     logger.warning(f'Ignored unsafe value: {weather_to_ignore}={ignored_value}')
-                
+
         # Do final safety check.
         safe = all(safety_params.values())
 

--- a/aag/weather.py
+++ b/aag/weather.py
@@ -752,7 +752,7 @@ class AAGCloudSensor(object):
         """
         Method makes decision whether conditions are safe or unsafe.
 
-        ignore: list of saftey params to ignore. Can be 'rain', 'wind', 'gust' or 'cloud'
+        ignore: list of safety params to ignore. Can be 'rain', 'wind', 'gust' or 'cloud'. If None (default) nothing is ignored.
         """
         logger.debug('Making safety decision')
         logger.debug(f'Found {len(self.weather_entries)} weather entries '

--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,7 @@ weather:
     threshold_wet: 2200
     threshold_rainy: 1800
     safety_delay: 15
-    ignore: None # can be a list, e.g. 'rain','cloud','gust','wind'
+    ignore_unsafe: None # can be a list, e.g. 'rain','cloud','gust','wind'
     heater:
       low_temp: 0
       low_delta: 6

--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,7 @@ weather:
     threshold_wet: 2200
     threshold_rainy: 1800
     safety_delay: 15
+    ignore: None # can be a list, e.g. 'rain','cloud','gust','wind'
     heater:
       low_temp: 0
       low_delta: 6


### PR DESCRIPTION
This is the fix for #20 . It adds the option to read in and ignore values from config. If it is False, no weather params are ignored, but if there are 'rain', 'clouds', 'gust' or 'wind' specified in a list they are then ignored when making the safety decision. 